### PR TITLE
Better status updating

### DIFF
--- a/Apps.md
+++ b/Apps.md
@@ -31,7 +31,7 @@ Some Apps require that you label nodes. In some cases, it's so the App knows whi
 
 - Go back to Apps.
 - Click the Nandy App.
-- Click a checkbox under labels to tell it which Nodes have speakers attached 
+- Click a checkbox under labels to tell it which Nodes have speakers attached
   - You can connect headphones to the node you selected for now
 
 ![speech](img/speech.png)
@@ -40,7 +40,7 @@ For you Kubernetes savy folks, yes this is labeling Nodes through traditional Ku
 
 ## Install
 
-- After labelling, click Install 
+- After labelling, click Install
 - Head over to the Pods page to watch the Pods come up (Status = Running).
   - Click the speech-nandy-io namespace to focus on the Pods we care about
 - Once they're all up, head back to Apps
@@ -59,16 +59,16 @@ Yep, that's a URL on your local network based on the App and Service name. For y
 
 ## Uzbeki Blues
 
-If you're on Windows, the URL of the Apps might not work.  If you're on an Android tablet, accessing the Apps probably won't work at all. We're using mDNS here and it's not fully supported on Windows/Android in some cases. 
+If you're on Windows, the URL of the Apps might not work.  If you're on an Android tablet, accessing the Apps probably won't work at all. We're using mDNS here and it's not fully supported on Windows/Android in some cases.
 
-Fortunately, we have a way around it, if you're down with some network settings. 
+Fortunately, we have a way around it, if you're down with some network settings.
 
 - Figure out the IP of your Master node
   - You should have already locked that in setting everything up
-- Go into your device's network DNS settings 
+- Go into your device's network DNS settings
 - Replace the DNS servers with the IP for your Master node
 
-NOTE: You best keep your Master node running for that device to work properly, whether you're using Klot I/O or not. 
+NOTE: You best keep your Master node running for that device to work properly, whether you're using Klot I/O or not.
 
 That's because the Master node of Klot I/O acts as a DNS server, serving our special mDNS records through regualr DNS, and passing everything else through to whatever the Pi is using for DNS. So while your errants devices can't use mDNS, we can fake them out a little with some mini DNS (Don't look up that term - I just made it up).
 
@@ -80,7 +80,7 @@ Here's a list of all the Apps with their current statuses:
 - yellow - barely remember how it works
 - red - vaporware
 
-| name | status | description | 
+| name | status | description |
 | ---- | ------ | ----------- |
 | [redis.klot.io](https://github.com/klot-io/redis) | blue | Redis server |
 | [mysql.klot.io](https://github.com/klot-io/mysql) | blue | MySQL server |

--- a/Development.md
+++ b/Development.md
@@ -272,7 +272,7 @@ If you want ot make your own image, go right ahead.
 On Mac:
 
 ```
-# Burn the latest raspbian image (images/2019-09-26-raspbian-buster-lite.zip currently) first then, pop it out and back in, then
+# Burn the latest lite raspbian image (2020-02-13-raspbian-buster-lite.zip currently) first then, pop it out and back in, then
 make build
 make boot
 ```
@@ -305,7 +305,9 @@ Will install and run the config daemon and then tails its logs to make sure it's
 
 The daemon sets hostname to klot-io, change pi password to 'kloudofthings', and reset network to eth0 (if needed)
 
-## enable tmpfs
+## enable tmpfs (optional)
+
+This will extend the SD card's life but I don't do it anymore as I think it causes all sorts of other problems.
 
 ```
 ./tmpfs.sh

--- a/Install.md
+++ b/Install.md
@@ -21,7 +21,7 @@ During installation, a lot of services and devices need to initialize and connec
 
 ### Burn klot.io to SD cards
 
-1. On your local workstation, download [pi-0.2.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.2.img.zip).
+1. On your local workstation, download [pi-0.3.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.3.img.zip).
 2. Burn this image to each of your SD cards.
 
 ### Add Raspberry Pi master node to your network
@@ -119,7 +119,7 @@ New requirements:
 
 Basically, you can run the Docker GUI locally and burn your settings right onto the cards before putting them into the Pi's.
 
-1. On your local workstation, download [pi-0.2.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.2.img.zip).
+1. On your local workstation, download [pi-0.3.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.3.img.zip).
 2. Burn this image to each of your SD cards.
 3. Pop the SD card out after burning and pop it back in.
 4. Enable the cross compiler with `make cross`. This allows ARM (Raspberry Pi processor) images to run on Docker.
@@ -167,7 +167,7 @@ cluster:   # name of the cluster
 name:      # name of the node (worker only)
 ```
 
-1. On your local workstation, download [pi-0.2.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.2.img.zip).
+1. On your local workstation, download [pi-0.3.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.3.img.zip).
 2. Burn this image to each of your SD cards.
 3. Pop the SD card out after burning and pop it back in.
 4. Create the three YAML files shown above in `/Volumes/boot/klot-io/config`.
@@ -188,7 +188,7 @@ This is how to boot off of an SSD hard drive for installation. I put this here b
 
 ### ### Burn klot.io to SSD
 
-1. On your local workstation, download [pi-0.2.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.2.img.zip).
+1. On your local workstation, download [pi-0.3.img.zip](https://klot-io.sfo2.cdn.digitaloceanspaces.com/pi-0.3.img.zip).
 2. Burn this image to each of your SSD.
 3. (Optional - set kubernetes to 'reset' for now, just safer) `make config`.
 4. Boot the Pi with the SSD attached (no SD card).

--- a/bin/klot-io.sh
+++ b/bin/klot-io.sh
@@ -5,6 +5,9 @@ set -e
 echo "setting account password"
 echo 'pi:kloudofthings' | sudo chpasswd
 
+echo "turning off rfkill"
+sudo rfkill unblock 0
+
 echo "setting hostname to klot-io"
 sudo sed -i s/raspberrypi/klot-io/g /etc/hosts
 sudo hostnamectl --transient set-hostname klot-io

--- a/config_requirements.txt
+++ b/config_requirements.txt
@@ -8,4 +8,8 @@ requests==2.21.0
 pyasn1==0.4.2
 git+https://github.com/klot-io/pykube.git@master#egg=pykube
 dnslib==0.9.10
+google-auth==1.14.0
+google-auth-oauthlib==0.4.1
+google-auth-httplib2==0.0.3
+google-api-python-client==1.8.0
 coverage==4.5.1

--- a/lib/name.py
+++ b/lib/name.py
@@ -139,7 +139,7 @@ class Daemon(object):
                 continue
 
             node = f"{sorted(nodes)[0]}.local"
-            host = f"{name}.{namespace}.{self.cluster}-klot-io.local"
+            host = f"{name}-{namespace}-{self.cluster}-klot-io.local"
 
             aliases[host] = node
 

--- a/www/apps.html
+++ b/www/apps.html
@@ -27,8 +27,8 @@
             <input id="url" placeholder="url" type="text" class="uk-form-width-large"/>
         </div>
         <div id="apps_action" class="uk-form-row" style="display: none;">
-            <button type="button" onClick="DRApp.current.controller.apps_action('Download');" class="uk-button uk-button-primary">
-                Download
+            <button type="button" onClick="DRApp.current.controller.apps_action('Preview');" class="uk-button uk-button-primary">
+                Preview
             </button>
             <button type="button" onClick="DRApp.current.controller.apps_action('Install');" class="uk-button uk-button-primary">
                 Install


### PR DESCRIPTION
There's two actions now. Preview and Install.  Preview was Download but while that's what's done, Preview is clearer via the intent of the User. Before there was like a Discover and a Define action but like what does those mean? How are they useful?  I'd like to either use an app or check it out first. So if there's anything about an App, it'll Download all the pieces to understand and still won't affect your Cluster until you say Install. It won't say it'll NeedSettings until you're trying Install it.  It won't say something's Installed until all the Manifests are applied and all their resources are Ready or Completed.  URL's won't be shown until they've been accessed and they work.  Finally, on a sadder note (yes, I'm pathetic) I had to change URL's from www.speech.nandy-io.klot-io.local to www-speech-nandy-io-klot-io.local. The multi dotted ones work on Mac's, where as only single dotted ones work on Windows and Chrome...and apparently Raspberry PI's. So the Pi's themselves counldn't resolve the fancy mDNS. So fuck it. Let's use what works for most things and not be super picky.